### PR TITLE
[GITHUT-12b] change to `mvn package` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A description of the takehome challenge can be found at [MoneyLion Java Take Hom
 
 ```
 cd <repo directory>
-mvn target
+mvn package
 java -jar target/moneylion-bounding-box-1.0-SNAPSHOT-jar-with-dependencies.jar < src/test/resources/simple.txt
 ```
 


### PR DESCRIPTION
# What does this PR do?

This PR changes the mvn build command to the correct `mvn package` in the Readme.

# How has this PR been tested?

Ran through these commands in command line successfully.